### PR TITLE
Library management

### DIFF
--- a/src/local_dbconfig.h
+++ b/src/local_dbconfig.h
@@ -1,6 +1,0 @@
-#ifndef LOCAL_DBCONFIG_H
-#define LOCAL_DBCONFIG_H
-
-const char* DBPATH = "/Users/niklaswulf/Dropbox/Public/projectstatsNewDB.db";
-
-#endif // LOCAL_DBCONFIG_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -158,7 +158,6 @@ HEADERS  += \
     ui/widgets/biggestdistancewidget.h \
     ui/game/settingswidget.h \
     misc/settings.h \
-    local_dbconfig.h \
     ui/widgets/clickablelabel.h \
     ui/game/gamelengthwidget.h \
     ui/game/recontrastatswidget.h \


### PR DESCRIPTION
Ich beginne mal mit der Entwicklung eines Library Managements. Folgende Features sollen nach und nach erledigt werden:
- [x] Auswahl der Datenbank über Kommandozeilenparameter: Hat Vorrang vor allen anderen Regeln, muss existieren, wird nicht angelegt.
- [x] Nutzung einer lokalen Datenbank (in ~/Library/Application Support), als Fallback, wenn keine andere (über Dropbox oder Kommandozeilenparameter etc) konfiguriert ist.
- [ ] Einfache Dropbox Erkennung: Gibt es den ~/Dropbox Ordner, benutze statt "Application Support" ~/Dropbox/ProjectStats/database.sqlite. Zuvor Nutzer Fragen?
- [ ] Einfacher Dropbox Share-support: ~/Dropbox/ProjectStats/Shared/SharedFolder wobei SharedFolder vom Nutzer per Hand mit anderen Dropbox Usern geteilt werden muss.
- [ ] Locks für Dropbox Shares? Wie?: ~/Dropbox/ProjectStats/Shared/SharedFolder/database.lock: Existenz prüfen, anlegen, etc.
- [ ] Nutzung der Dropbox API, statt "lokalem" Dateisystem: https://github.com/lycis/QtDropbox
        -> Dropbox muss nicht mehr im Hintergrund laufen. Bessere Sicherheit für die Locks?
- [ ] UI für alle Features: Noch keine tollen Ideen.

Mit der Erledigung von Punkt 1 ändert sich übrigens etwas für uns: Wir müssen uns Run-Configurations in Qt Creator anlegen. Ich habe jetzt zwei Dateien in ~/Dropbox/Public/ProjectStats/: projectstats.db und projectstats_TEST.db. Erstere wird immer die aktuelle korrekte Datenbank darstellen, zweiteres wird meine Testdatenbank werden, in der ich rumspielen kann und die immer von der aktuellen überschrieben werden wird.
Dazu passend habe ich zwei Run-Configurations "Production" und "TEST", die die Datenbanken entsprechend als Kommandozeilenparameter übergeben. So finde ich das hin und herwechseln zwischen Datenbanken einfacher und wir sind diese unsägliche "local_dbconfig.h" endlich los.

Kann ich die Punkte 1 und 2 schonmal nach master packen?

![screen shot 2014-02-05 at 10 34 23](https://f.cloud.github.com/assets/1001092/2085632/c0a0849a-8e48-11e3-8adb-6b347c15fd10.png)
